### PR TITLE
ttc-dashboard-ui to 0.0.37

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 1.0.12
 - name: ttc-dashboard-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.37


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.37